### PR TITLE
fix addAttribute for Node and Edge

### DIFF
--- a/gexf/_gexf.py
+++ b/gexf/_gexf.py
@@ -490,7 +490,7 @@ class Node :
         #self._graph.addDefaultAttributesToNode(self)
         
     def addAttribute(self,id,value,start="",end="",startopen=False,endopen=False) :
-        self._attributes.append(makeAttributeInstance(self,"node",id,value,start,end,startopen,endopen))
+        self._attributes.append(self._graph.attributes.makeAttributeInstance("node",id,value,start,end,startopen,endopen))
             
     def getXML(self) :
         # return lxml etree element
@@ -643,7 +643,7 @@ class Edge :
         
         
     def addAttribute(self,id,value,start="",end="",startopen=False,endopen=False) :
-        self._attributes.append(makeAttributeInstance(self,"node",id,value,start,end,startopen,endopen))
+        self._attributes.append(self._graph.attributes.makeAttributeInstance("node",id,value,start,end,startopen,endopen))
         
     
     def getXML(self) :


### PR DESCRIPTION
makeAttributeInstance was called as if it was a global; it should be called on the
Attributes instance of the owner Graph.
