### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/users.rst
+++ b/doc/users.rst
@@ -38,12 +38,12 @@ If no errors are raised then you're done.
 embed pygexf in your project
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This is a quick and durty method. Use easy_install instead.
+This is a quick and dirty method. Use easy_install instead.
 (but still sometime usefull)
 
 pygexf is a single file package.
-You can decide not to install it in your python environement but directly in your source where you need it.
-In such case go directly to the soruce repository :
+You can decide not to install it in your python environment but directly in your source where you need it.
+In such case go directly to the source repository :
 http://github.com/paulgirard/pygexf
 
 Download the gexf directory to your source.

--- a/gexf/_gexf.py
+++ b/gexf/_gexf.py
@@ -7,7 +7,7 @@
 #     repository : http://github.com/paulgirard/pygexf
 #     documentation : http://packages.python.org/pygexf
 #
-#     main developper : Paul Girard, médialab Sciences Po
+#     main developer : Paul Girard, médialab Sciences Po
 #     licence : GPL v3
 #
 
@@ -23,7 +23,7 @@ import traceback
 
  # evolution ideas :
  # add display stats on graph composition when exportingto xml
- # add anti-paralell edges test
+ # add anti-parallel edges test
 
 def msg_unexpected_tag(expected, got):
     print("Error : incorrect xml. Expected tag {expected}, not {got}.".format(expected=expected, got=got))
@@ -485,7 +485,7 @@ class Node:
 
         self._attributes = []
         self.attributes = self._attributes
-        # add existing nodesattributes default values : bad idea and unecessary
+        # add existing nodesattributes default values : bad idea and unnecessary
         #self._graph.addDefaultAttributesToNode(self)
 
     def addAttribute(self, id, value, start="", end="", startopen=False, endopen=False):
@@ -631,7 +631,7 @@ class Edge:
 
         #spells expecting format = [{start:"",end:""},...]
         self.spells = Spells(spells)
-        # add existing nodesattributes default values : bad idea and unecessary
+        # add existing nodesattributes default values : bad idea and unnecessary
         #self._graph.addDefaultAttributesToEdge(self)
 
     def addAttribute(self, id, value, start="", end="", startopen=False, endopen=False):


### PR DESCRIPTION
There are small typos in:
- doc/users.rst
- gexf/_gexf.py

Fixes:
- Should read `unnecessary` rather than `unecessary`.
- Should read `source` rather than `soruce`.
- Should read `parallel` rather than `paralell`.
- Should read `environment` rather than `environement`.
- Should read `dirty` rather than `durty`.
- Should read `developer` rather than `developper`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md